### PR TITLE
Fixes zero strings being accidentally evaluated as non-existing values

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -419,7 +419,10 @@ function tag_tools_get_unsent_tags(ElggEntity $entity) {
 	}
 	
 	$entity_tags = $entity->tags;
-	if (empty($entity_tags)) {
+	
+	// Cannot use empty() because it would evaluate
+	// the string "0" as an empty value.
+	if (is_null($entity_tags)) {
 		// shouldn't happen
 		return false;
 	} elseif (!is_array($entity_tags)) {


### PR DESCRIPTION
String values were being checked using the empty() function. Therefore the string "0" was erroneously evaluated as no value at all. Now the existence of the values is checked with is_null() instead.
